### PR TITLE
Change domain name to symfony.local

### DIFF
--- a/nginx/symfony.conf
+++ b/nginx/symfony.conf
@@ -1,5 +1,5 @@
 server {
-    server_name symfony.dev;
+    server_name symfony.local;
     root /var/www/symfony/public;
 
 


### PR DESCRIPTION
This is a fix for .dev domains redirected to https in latest versions of Chrome #67. Changed symfony.dev domain name to symfony.local. 